### PR TITLE
Add pytest-xvfb as dependency to run test suite.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
         "Pillow",
         "ipywidgets",
         "pytest",
+        "pytest-xvfb",
         "moderngl<6",
         "opencv-python",
         "torch"


### PR DESCRIPTION
The test suite depends on ``pyest-xvfb``. Since ``pytest`` is already listed in ``setup.py``, should probably add this one.

``pytest_xvfb`` in test suite: https://github.com/cinemascience/pycinema/blob/master/testing/CinemaRenderTest.py#L2