### PR TITLE
fixes for tf2.17

### DIFF
--- a/pycinema/filters/MLTFPredictor.py
+++ b/pycinema/filters/MLTFPredictor.py
@@ -26,9 +26,9 @@ class MLTFPredictor(Filter):
         modelList = self.inputs.trainedModel.get()
         # get required input properties from first model
         model = modelList[0]
-        width = model.layers[0].input_shape[1]
-        height = model.layers[0].input_shape[2]
-        channels = model.layers[0].input_shape[3]
+        width = model.input_shape[1]
+        height = model.input_shape[2]
+        channels = model.input_shape[3]
         if channels == 1:
           gray_req = True
         else: #channels == 3 or 4

--- a/pycinema/filters/MLTFReader.py
+++ b/pycinema/filters/MLTFReader.py
@@ -39,7 +39,7 @@ class MLTFReader(Filter):
             models = []
             # if the path directly points to a TF model
             if modelPath.endswith(".h5") or modelPath.endswith(".keras"):
-                model = tf.keras.models.load_model(modelPath)
+                model = tf.keras.models.load_model(modelPath, compile=False)
                 models.append(model)
 
             else:
@@ -59,7 +59,7 @@ class MLTFReader(Filter):
                 for row in table:
                     parent = os.path.dirname(modelPath) + "/"
                     filePath = os.path.join(parent, row[1])
-                    model = tf.keras.models.load_model(filePath)      
+                    model = tf.keras.models.load_model(filePath, compile=False)      
                     models[int(row[0])] = model
             
             #check if training configuration exists, if not give error


### PR DESCRIPTION
adding updates for change of tensorflow version from tf 2.15 to tf 2.17. 
It seems we're now using tf 2.17 as our default version and there have been some changes in the functionality. The old .h5 was no longer compatible so I've retrained the model and included an updated mnist_tf.h5 file. In addition, some of the functions have changed and those are updated too. 