### PR TITLE
Enable TextFileReader filter and allow multiple text files

### DIFF
--- a/pycinema/filters/__init__.py
+++ b/pycinema/filters/__init__.py
@@ -37,6 +37,7 @@ from .SqliteDatabaseReader import *
 from .TableWriter import *
 from .TableView import *
 from .TextEditor import *
+from .TextFileReader import *
 from .ParametersView import *
 from .ParallelCoordinates import *
 from .InspectorView import *


### PR DESCRIPTION
There is a potential usecase for viewing text files as part of a cinema database. This PR enables the TextFileReader to be an available filter. It also enables reading multiple text files and combining into a single text to be viewed or used later. Would be good if this PR, or something similar could be added to pycinema.

Thanks