### PR TITLE
CI Workflows: pip install . instead of setup.py install

### DIFF
--- a/.github/workflows/MLPredictionTest.yml
+++ b/.github/workflows/MLPredictionTest.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install pytest pytest-xvfb
       - name: Dependencies
         run: |
-          python setup.py install
+          python -m pip install .
       - name: Test reader
         run: |
           python -m pytest -s testing/MLPredictTest.py
@@ -45,7 +45,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           python -m pip install pytest
-          python setup.py install
+          python -m pip install .
       - name: Test reader
         run: |
           python -m pytest -s testing/MLPredictTest.py

--- a/.github/workflows/RenderTest.yml
+++ b/.github/workflows/RenderTest.yml
@@ -25,7 +25,7 @@ jobs:
           python -m pip install pytest pytest-xvfb
       - name: Dependencies
         run: |
-          python setup.py install
+          python -m pip install .
       - name: Test composite script 
         run: |
           cinema compose examples/scalar-images_config.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           python -m pip install pytest
-          python setup.py install
+          python -m pip install .
       - name: Test composite script 
         run: |
           cinema compose examples/scalar-images_config.yaml
@@ -83,7 +83,7 @@ jobs:
 #       run: |
 #         python -m pip install --upgrade pip setuptools
 #         python -m pip install pytest
-#         python setup.py install
+#         python -m pip install .
 #     - name: Test using ModernGL
 #       run: |
 #         python -m pytest -s testing/RenderTest.py

--- a/.github/workflows/UberTest.yml
+++ b/.github/workflows/UberTest.yml
@@ -25,7 +25,7 @@ jobs:
           python -m pip install pytest pytest-xvfb
       - name: Dependencies
         run: |
-          python setup.py install
+          python -m pip install .
       - name: Test execution
         run: |
           python examples/python/TableWriteExample.py
@@ -52,7 +52,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           python -m pip install pytest
-          python setup.py install
+          python -m pip install .
       - name: Test execution
         run: |
           python examples/python/TableWriteExample.py
@@ -87,7 +87,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           python -m pip install pytest
-          python setup.py install
+          python -m pip install .
       - name: Test execution
         run: |
           python examples/python/TableWriteExample.py


### PR DESCRIPTION
@dhrogers @JonasLukasczyk 

This changes all `python setup.py install` commands to `python -m pip install .` in the CI workflows. All tests passed in my branch, so I hope this fixes the issue in the dev branch.